### PR TITLE
fix: clear older frames to prevent overlapping images

### DIFF
--- a/src/common/canvas.ts
+++ b/src/common/canvas.ts
@@ -156,6 +156,7 @@ export class Canvas extends Options {
    * @param image 
    */
   public drawImage(image: HTMLImageElement): void {
+    this.context.clearRect(0, 0, this.viewport.width, this.viewport.height);
     this.context.drawImage(image, 0, 0, this.viewport.width, this.viewport.height);
   }
 


### PR DESCRIPTION
Fix for the issue with older images being displayed below new ones (especially in case of png with transparent background).